### PR TITLE
Program options and Synopsis syntax

### DIFF
--- a/syntax/man.vim
+++ b/syntax/man.vim
@@ -31,6 +31,9 @@ syntax region manFiles     start='^FILES'hs=s+5 end='^\u[A-Z ]*$'me=e-30 keepend
 syntax match manEnvVar     display '\s\zs\(\u\|_\)\{3,}' contained
 syntax region manFiles     start='^ENVIRONMENT'hs=s+11 end='^\u[A-Z ]*$'me=e-30 keepend contains=manReference,manSectionHeading,manHeaderFile,manURL,manEmail,manEnvVar
 
+" Options
+syntax match manOptions  '\v[^a-z0-9]\zs-{1,2}[[:alnum:]\-\_]+\ze'
+
 hi def link manTitle           Title
 hi def link manSectionHeading  Statement
 hi def link manOptionDesc      Constant
@@ -46,6 +49,7 @@ hi def link manFile            Identifier
 hi def link manEnvVarFile      Identifier
 hi def link manEnvVar          Identifier
 hi def link manHighlight       Statement
+hi def link manOptions         Identifier
 
 let b:current_syntax = 'man'
 

--- a/syntax/man.vim
+++ b/syntax/man.vim
@@ -34,6 +34,9 @@ syntax region manFiles     start='^ENVIRONMENT'hs=s+11 end='^\u[A-Z ]*$'me=e-30 
 " Options
 syntax match manOptions  '\v[^a-z0-9]\zs-{1,2}[[:alnum:]\-\_]+\ze'
 
+" SYNOPSIS Section
+syntax match manSynOptions  '\v\[\U*\zs[A-Z]{4,}\ze.*\]'
+
 hi def link manTitle           Title
 hi def link manSectionHeading  Statement
 hi def link manOptionDesc      Constant
@@ -50,6 +53,7 @@ hi def link manEnvVarFile      Identifier
 hi def link manEnvVar          Identifier
 hi def link manHighlight       Statement
 hi def link manOptions         Identifier
+hi def link manSynOptions      Underlined
 
 let b:current_syntax = 'man'
 


### PR DESCRIPTION
- Add program options syntax: `man` show program options with different colors, so `vim-man` should do that too (looks nicer)

- Add Synopsis section syntax: (issue #4 )?

*Result:   `$ viman 1 grep`*

![Result](http://i.imgur.com/URjv4t3.png)

