### PR TITLE
Add option to choose default split type

### DIFF
--- a/doc/man.txt
+++ b/doc/man.txt
@@ -116,6 +116,16 @@ Default man command is '/usr/bin/man', but it can be changed:
 >
   let g:vim_man_cmd = 'LANG=ja_JP.UTF-8 /usr/bin/man'
 <
+
+
+man_split_type                          *g:man_split_type*
+Change the default split type when using |:Man|. Valid values are
+'horizontal', 'vertical', or 'tab'
+
+>
+  let g:man_split_type = 'horizontal'
+<
+
 CONTRIBUTING					*man-contributing* *man-bugs*
 
 Contributing and bug fixes are welcome. If you have an idea for a new feature

--- a/plugin/man.vim
+++ b/plugin/man.vim
@@ -10,7 +10,11 @@ if !exists('g:vim_man_cmd')
   let g:vim_man_cmd='/usr/bin/man'
 endif
 
-command! -nargs=* -bar -complete=customlist,man#completion#run Man  call man#get_page('horizontal', <f-args>)
+if !exists('g:man_split_type')
+  let g:man_split_type = 'horizontal'
+endif
+
+command! -nargs=* -bar -complete=customlist,man#completion#run Man  call man#get_page(g:man_split_type, <f-args>)
 command! -nargs=* -bar -complete=customlist,man#completion#run Sman call man#get_page('horizontal', <f-args>)
 command! -nargs=* -bar -complete=customlist,man#completion#run Vman call man#get_page('vertical',   <f-args>)
 command! -nargs=* -bar -complete=customlist,man#completion#run Tman call man#get_page('tab',        <f-args>)
@@ -18,7 +22,7 @@ command! -nargs=* -bar -complete=customlist,man#completion#run Tman call man#get
 command! -nargs=+ -bang Mangrep call man#grep#run(<bang>0, <f-args>)
 
 " map a key to open a manpage for word under cursor, example: map ,k <Plug>(Man)
-nnoremap <silent> <Plug>(Man)  :<C-U>call man#get_page_from_cword('horizontal', v:count)<CR>
+nnoremap <silent> <Plug>(Man)  :<C-U>call man#get_page_from_cword(g:man_split_type, v:count)<CR>
 nnoremap <silent> <Plug>(Sman) :<C-U>call man#get_page_from_cword('horizontal', v:count)<CR>
 nnoremap <silent> <Plug>(Vman) :<C-U>call man#get_page_from_cword('vertical',   v:count)<CR>
 


### PR DESCRIPTION
This adds a new variable that can be set to influence the default split
method when using `:Man`. It also works on `K`.

The other commands `Vman`, etc are unaffected.
