### PR TITLE
Fix calculation of buffer width when signcolumn is enabled

### DIFF
--- a/ftplugin/man.vim
+++ b/ftplugin/man.vim
@@ -17,6 +17,7 @@ setlocal iskeyword+=\.,-
 setlocal nonumber
 setlocal norelativenumber
 setlocal foldcolumn=0
+setlocal signcolumn=no
 setlocal nofoldenable
 setlocal nolist
 


### PR DESCRIPTION
Explicitly disables the signcolumn for the manpage buffer

Fixes https://github.com/vim-utils/vim-man/issues/51